### PR TITLE
archive.go: force add vendor directory

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -46,7 +46,7 @@ func main() {
 		}
 		log.Fatalf("'go mod graph' shows dependencies but vendor folder absent after a 'go mod vendor'")
 	}
-	run(exec.Command("git", "add", "vendor"))
+	run(exec.Command("git", "add", "-f", "vendor"))
 	msg := fmt.Sprintf("go mod vendor from a go.mod with SHA-256 of %v", modSum)
 	os.Setenv("GIT_AUTHOR_NAME", "go-mod-archiver")
 	os.Setenv("GIT_AUTHOR_EMAIL", "go-mod-archiver@tailscale.github.fakeemail")


### PR DESCRIPTION
We .gitignore the top-level vendor directory in corp because we don't want to accidentally check it in to git.  This is an exception to that rule where we really do want to check it in.